### PR TITLE
Forbid unsafe code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = ["benches/", "tests/"]
 
 [dependencies]
 bitflags = "2.4.1"
-bytemuck = { version = "1.5", features = ["extern_crate_alloc"] }
+bytemuck = { version = "1.5", features = ["extern_crate_alloc", "derive"] }
 core_maths = "0.1.0" # only for no_std builds
 smallvec = "1.6"
 unicode-bidi-mirroring = "0.3.0"

--- a/README.md
+++ b/README.md
@@ -99,11 +99,8 @@ All of this is a lot of work, so contributions are more than welcome.
 
 ## Safety
 
-The library is completely safe.
-
-We do have one `unsafe` to cast between two POD structures, which is perfectly safe.
-But except that, there are no `unsafe` in this library and in most of its dependencies
-(excluding `bytemuck`).
+Unsafe code is forbidden by a `#![forbid(unsafe_code)]` attribute in the root
+of the library.
 
 ## Alternatives
 

--- a/src/hb/buffer.rs
+++ b/src/hb/buffer.rs
@@ -1,4 +1,5 @@
 use alloc::{string::String, vec::Vec};
+use bytemuck::{Pod, Zeroable};
 use core::cmp::min;
 use core::convert::TryFrom;
 use ttf_parser::GlyphId;
@@ -105,7 +106,7 @@ pub mod glyph_flag {
 ///
 /// All positions are relative to the current point.
 #[repr(C)]
-#[derive(Clone, Copy, Default, Debug)]
+#[derive(Clone, Copy, Default, Debug, Zeroable, Pod)]
 pub struct GlyphPosition {
     /// How much the line advances after drawing this glyph when setting text in
     /// horizontal direction.
@@ -121,9 +122,6 @@ pub struct GlyphPosition {
     pub y_offset: i32,
     pub(crate) var: u32,
 }
-
-unsafe impl bytemuck::Zeroable for GlyphPosition {}
-unsafe impl bytemuck::Pod for GlyphPosition {}
 
 impl GlyphPosition {
     #[inline]
@@ -157,7 +155,7 @@ impl GlyphPosition {
 
 /// A glyph info.
 #[repr(C)]
-#[derive(Clone, Copy, Default, Debug)]
+#[derive(Clone, Copy, Default, Debug, Zeroable, Pod)]
 pub struct hb_glyph_info_t {
     // NOTE: Stores a Unicode codepoint before shaping and a glyph ID after.
     //       Just like harfbuzz, we are using the same variable for two purposes.
@@ -174,9 +172,6 @@ pub struct hb_glyph_info_t {
     pub(crate) var1: u32,
     pub(crate) var2: u32,
 }
-
-unsafe impl bytemuck::Zeroable for hb_glyph_info_t {}
-unsafe impl bytemuck::Pod for hb_glyph_info_t {}
 
 impl hb_glyph_info_t {
     /// Indicates that if input text is broken at the beginning of the cluster this glyph

--- a/src/hb/face.rs
+++ b/src/hb/face.rs
@@ -1,3 +1,4 @@
+use bytemuck::{Pod, Zeroable};
 #[cfg(not(feature = "std"))]
 use core_maths::CoreFloat;
 
@@ -351,7 +352,7 @@ impl<'a> hb_font_t<'a> {
     }
 }
 
-#[derive(Clone, Copy, Default)]
+#[derive(Clone, Copy, Default, Zeroable, Pod)]
 #[repr(C)]
 pub struct hb_glyph_extents_t {
     pub x_bearing: i32,
@@ -359,6 +360,3 @@ pub struct hb_glyph_extents_t {
     pub width: i32,
     pub height: i32,
 }
-
-unsafe impl bytemuck::Zeroable for hb_glyph_extents_t {}
-unsafe impl bytemuck::Pod for hb_glyph_extents_t {}

--- a/src/hb/shape_wasm.rs
+++ b/src/hb/shape_wasm.rs
@@ -1,4 +1,5 @@
 use alloc::{borrow::ToOwned, ffi::CString, format};
+use bytemuck::{Pod, Zeroable};
 use core::ffi::CStr;
 use ttf_parser::{GlyphId, Tag};
 use wasmi::{self, AsContextMut, Caller, Config, Engine, Linker, Module, Store};
@@ -224,7 +225,7 @@ enum PointType {
 }
 
 #[repr(C)]
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Zeroable, Pod)]
 struct OutlinePoint {
     x: f32,
     y: f32,
@@ -235,9 +236,6 @@ impl OutlinePoint {
         OutlinePoint { x, y, kind }
     }
 }
-
-unsafe impl bytemuck::Zeroable for OutlinePoint {}
-unsafe impl bytemuck::Pod for OutlinePoint {}
 
 #[derive(Default)]
 struct GlyphOutline {
@@ -279,16 +277,13 @@ impl ttf_parser::OutlineBuilder for GlyphOutline {
 }
 
 #[repr(C)]
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Zeroable, Pod)]
 struct CGlyphOutline {
     n_points: u32,
     points: u32, // pointer
     n_contours: u32,
     contours: u32, // pointer
 }
-
-unsafe impl bytemuck::Zeroable for CGlyphOutline {}
-unsafe impl bytemuck::Pod for CGlyphOutline {}
 
 // fn font_copy_glyph_outline(font: u32, glyph: u32, outline: *mut CGlyphOutline) -> bool;
 // Copies the outline of the given glyph ID, at current scale and variation settings, into the outline structure provided.
@@ -352,15 +347,12 @@ fn font_copy_glyph_outline(
 }
 
 #[repr(C)]
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Zeroable, Pod)]
 struct Blob {
     // Length of the blob in bytes
     length: u32,
     data: u32, // pointer
 }
-
-unsafe impl bytemuck::Zeroable for Blob {}
-unsafe impl bytemuck::Pod for Blob {}
 
 // fn face_copy_table(font: u32, tag: u32, blob: *mut Blob) -> bool;
 // Copies the binary data in the OpenType table referenced by tag into the supplied blob structure.
@@ -462,15 +454,12 @@ fn buffer_copy_contents(mut caller: Caller<'_, ShapingData>, _buffer: u32, cbuff
 }
 
 #[repr(C)]
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Zeroable, Pod)]
 struct CBufferContents {
     length: u32,
     info: u32,     // pointer
     position: u32, // pointer
 }
-
-unsafe impl bytemuck::Zeroable for CBufferContents {}
-unsafe impl bytemuck::Pod for CBufferContents {}
 
 // fn buffer_set_contents(buffer: u32, cbuffer: &CBufferContents) -> bool;
 // Copy the buffer_contents structure back into the host shaping engine's buffer. This should typically be called at the end of shaping.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ A complete [harfbuzz](https://github.com/harfbuzz/harfbuzz) shaping algorithm po
 */
 
 #![no_std]
+#![forbid(unsafe_code)]
 #![warn(missing_docs)]
 
 #[cfg(feature = "std")]


### PR DESCRIPTION
We already depend on `bytemuck_derive` through `font-types`, so we might as well use this to remove any remaining unsafe code.