### PR TITLE
Re-export types used in the public API

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,10 @@ extern crate alloc;
 
 mod hb;
 
-pub use read_fonts::FontRef;
+pub use read_fonts::{
+    types::{F2Dot14, Tag},
+    FontRef,
+};
 
 pub use hb::buffer::hb_glyph_info_t as GlyphInfo;
 pub use hb::buffer::{GlyphBuffer, GlyphPosition, UnicodeBuffer};


### PR DESCRIPTION
That is `Tag` and `F2Dot14`. Looks like `FontRef` is already available.