### PR TITLE
Add support for cmap format 13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,8 +63,9 @@ checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
 
 [[package]]
 name = "font-types"
-version = "0.8.4"
-source = "git+https://github.com/googlefonts/fontations?branch=cmap-format-13#4ba610c164a91723be271b0f1c92c5482a5606a1"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02a596f5713680923a2080d86de50fe472fb290693cf0f701187a1c8b36996b7"
 dependencies = [
  "bytemuck",
 ]
@@ -158,8 +159,9 @@ dependencies = [
 
 [[package]]
 name = "read-fonts"
-version = "0.28.0"
-source = "git+https://github.com/googlefonts/fontations?branch=cmap-format-13#4ba610c164a91723be271b0f1c92c5482a5606a1"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ce8e2ca6b24313587a03ca61bb74c384e2a815bd90cf2866cfc9f5fb7a11fa0"
 dependencies = [
  "bytemuck",
  "core_maths",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,8 +64,7 @@ checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
 [[package]]
 name = "font-types"
 version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa6a5e5a77b5f3f7f9e32879f484aa5b3632ddfbe568a16266c904a6f32cdaf"
+source = "git+https://github.com/googlefonts/fontations?branch=cmap-format-13#4ba610c164a91723be271b0f1c92c5482a5606a1"
 dependencies = [
  "bytemuck",
 ]
@@ -160,8 +159,7 @@ dependencies = [
 [[package]]
 name = "read-fonts"
 version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "600e807b48ac55bad68a8cb75cc3c7739f139b9248f7e003e01e080f589b5288"
+source = "git+https://github.com/googlefonts/fontations?branch=cmap-format-13#4ba610c164a91723be271b0f1c92c5482a5606a1"
 dependencies = [
  "bytemuck",
  "core_maths",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,7 @@ unicode-properties = { version = "0.1", default-features = false, features = ["g
 unicode-script = "0.5"
 wasmi = { version = "0.40", optional = true }
 log = "0.4"
-# read-fonts = { version = "0.28.0", default-features = false, features = ["libm"] }
-read-fonts = { git = "https://github.com/googlefonts/fontations", branch= "cmap-format-13", default-features = false, features = ["libm"] }
+read-fonts = { version = "0.29.0", default-features = false, features = ["libm"] }
 
 # TODO: remove entirely
 [dependencies.ttf-parser]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,8 @@ unicode-properties = { version = "0.1", default-features = false, features = ["g
 unicode-script = "0.5"
 wasmi = { version = "0.40", optional = true }
 log = "0.4"
-read-fonts = { version = "0.28.0", default-features = false, features = ["libm"] }
+# read-fonts = { version = "0.28.0", default-features = false, features = ["libm"] }
+read-fonts = { git = "https://github.com/googlefonts/fontations", branch= "cmap-format-13", default-features = false, features = ["libm"] }
 
 # TODO: remove entirely
 [dependencies.ttf-parser]

--- a/src/hb/charmap.rs
+++ b/src/hb/charmap.rs
@@ -73,6 +73,7 @@ impl<'a> Charmap<'a> {
             }
             CmapSubtable::Format4(table) => table.map_codepoint(c),
             CmapSubtable::Format12(table) => table.map_codepoint(c),
+            CmapSubtable::Format13(table) => table.map_codepoint(c),
             _ => None,
         };
         if result.is_none()
@@ -134,7 +135,8 @@ fn find_cmap_subtable<'a>(
                 | CmapSubtable::Format4(_)
                 | CmapSubtable::Format6(_)
                 | CmapSubtable::Format10(_)
-                | CmapSubtable::Format12(_) => return Some((platform_id, encoding_id, subtable)),
+                | CmapSubtable::Format12(_)
+                | CmapSubtable::Format13(_) => return Some((platform_id, encoding_id, subtable)),
                 _ => {}
             }
         }


### PR DESCRIPTION
Currently based on a git dependency so shouldn't be merged until a new version of read-fonts is released.