### PR TITLE
Skippy iter  refactor

### DIFF
--- a/src/hb/aat_layout_kerx_table.rs
+++ b/src/hb/aat_layout_kerx_table.rs
@@ -156,7 +156,8 @@ fn apply_simple_kerning(
             continue;
         }
 
-        let mut iter = skipping_iterator_t::new(&ctx, i, false);
+        let mut iter = skipping_iterator_t::new(&ctx, false);
+        iter.reset(i);
 
         let mut unsafe_to = 0;
         if !iter.next(Some(&mut unsafe_to)) {

--- a/src/hb/kerning.rs
+++ b/src/hb/kerning.rs
@@ -82,7 +82,8 @@ fn machine_kern(
             continue;
         }
 
-        let mut iter = skipping_iterator_t::new(&ctx, i, false);
+        let mut iter = skipping_iterator_t::new(&ctx, false);
+        iter.reset(i);
 
         let mut unsafe_to = 0;
         if !iter.next(Some(&mut unsafe_to)) {

--- a/src/hb/ot/gpos/cursive.rs
+++ b/src/hb/ot/gpos/cursive.rs
@@ -16,7 +16,8 @@ impl Apply for CursivePosFormat1<'_> {
         let offset_data = self.offset_data();
         let entry_this = records.get(index_this)?.entry_anchor(offset_data)?.ok()?;
 
-        let mut iter = skipping_iterator_t::new(ctx, ctx.buffer.idx, false);
+        let mut iter = skipping_iterator_t::new(ctx, false);
+        iter.reset_fast(ctx.buffer.idx);
 
         let mut unsafe_from = 0;
         if !iter.prev(Some(&mut unsafe_from)) {

--- a/src/hb/ot/gpos/mark.rs
+++ b/src/hb/ot/gpos/mark.rs
@@ -69,7 +69,7 @@ impl Apply for MarkBasePosFormat1<'_> {
 
         // Now we search backwards for a non-mark glyph
         // We don't use skippy_iter.prev() to avoid O(n^2) behavior.
-        let mut iter = skipping_iterator_t::new(ctx, 0, false);
+        let mut iter = skipping_iterator_t::new(ctx, false);
         iter.set_lookup_props(u32::from(lookup_flags::IGNORE_MARKS));
 
         let mut j = buffer.idx;
@@ -150,7 +150,8 @@ impl Apply for MarkMarkPosFormat1<'_> {
         let mark1_index = self.mark1_coverage().ok()?.get(mark1_glyph)?;
 
         // Now we search backwards for a suitable mark glyph until a non-mark glyph
-        let mut iter = skipping_iterator_t::new(ctx, buffer.idx, false);
+        let mut iter = skipping_iterator_t::new(ctx, false);
+        iter.reset_fast(buffer.idx);
         iter.set_lookup_props(ctx.lookup_props & !u32::from(lookup_flags::IGNORE_FLAGS));
 
         let mut unsafe_from = 0;
@@ -220,7 +221,7 @@ impl Apply for MarkLigPosFormat1<'_> {
         }
 
         // Now we search backwards for a non-mark glyph
-        let mut iter = skipping_iterator_t::new(ctx, 0, false);
+        let mut iter = skipping_iterator_t::new(ctx, false);
         iter.set_lookup_props(u32::from(lookup_flags::IGNORE_MARKS));
 
         let mut j = buffer.idx;

--- a/src/hb/ot/gpos/pair.rs
+++ b/src/hb/ot/gpos/pair.rs
@@ -13,7 +13,8 @@ impl Apply for PairPosFormat1<'_> {
         let first_glyph = ctx.buffer.cur(0).as_glyph();
         let first_glyph_coverage_index = self.coverage().ok()?.get(first_glyph)?;
 
-        let mut iter = skipping_iterator_t::new(ctx, ctx.buffer.idx, false);
+        let mut iter = skipping_iterator_t::new(ctx, false);
+        iter.reset(ctx.buffer.idx);
 
         let mut unsafe_to = 0;
         if !iter.next(Some(&mut unsafe_to)) {
@@ -126,7 +127,8 @@ impl Apply for PairPosFormat2<'_> {
         let first_glyph = ctx.buffer.cur(0).as_glyph();
         self.coverage().ok()?.get(first_glyph)?;
 
-        let mut iter = skipping_iterator_t::new(ctx, ctx.buffer.idx, false);
+        let mut iter = skipping_iterator_t::new(ctx, false);
+        iter.reset(ctx.buffer.idx);
 
         let mut unsafe_to = 0;
         if !iter.next(Some(&mut unsafe_to)) {

--- a/src/hb/ot_layout.rs
+++ b/src/hb/ot_layout.rs
@@ -2,12 +2,12 @@
 
 use core::ops::{Index, IndexMut};
 
-use crate::hb::ot_layout_gsubgpos::OT::check_glyph_property;
 use super::buffer::*;
 use super::ot_layout_gsubgpos::{Apply, OT};
 use super::ot_shape_plan::hb_ot_shape_plan_t;
 use super::unicode::{hb_unicode_funcs_t, hb_unicode_general_category_t, GeneralCategoryExt};
 use super::{hb_font_t, hb_glyph_info_t};
+use crate::hb::ot_layout_gsubgpos::OT::check_glyph_property;
 use crate::hb::set_digest::hb_set_digest_t;
 
 pub const MAX_NESTING_LEVEL: usize = 64;

--- a/src/hb/ot_layout.rs
+++ b/src/hb/ot_layout.rs
@@ -2,6 +2,7 @@
 
 use core::ops::{Index, IndexMut};
 
+use crate::hb::ot_layout_gsubgpos::OT::check_glyph_property;
 use super::buffer::*;
 use super::ot_layout_gsubgpos::{Apply, OT};
 use super::ot_shape_plan::hb_ot_shape_plan_t;
@@ -177,7 +178,7 @@ fn apply_forward(ctx: &mut OT::hb_ot_apply_context_t, lookup: &impl Apply) -> bo
     while ctx.buffer.idx < ctx.buffer.len && ctx.buffer.successful {
         let cur = ctx.buffer.cur(0);
         if (cur.mask & ctx.lookup_mask()) != 0
-            && ctx.check_glyph_property(cur, ctx.lookup_props)
+            && check_glyph_property(ctx.face, cur, ctx.lookup_props)
             && lookup.apply(ctx).is_some()
         {
             ret = true;
@@ -193,7 +194,7 @@ fn apply_backward(ctx: &mut OT::hb_ot_apply_context_t, lookup: &impl Apply) -> b
     loop {
         let cur = ctx.buffer.cur(0);
         ret |= (cur.mask & ctx.lookup_mask()) != 0
-            && ctx.check_glyph_property(cur, ctx.lookup_props)
+            && check_glyph_property(ctx.face, cur, ctx.lookup_props)
             && lookup.apply(ctx).is_some();
 
         if ctx.buffer.idx == 0 {

--- a/src/hb/ot_layout_gsubgpos.rs
+++ b/src/hb/ot_layout_gsubgpos.rs
@@ -1,6 +1,5 @@
 //! Matching of glyph patterns.
 
-use crate::hb::ot_layout_gsubgpos::OT::check_glyph_property;
 use super::buffer::hb_glyph_info_t;
 use super::buffer::{hb_buffer_t, GlyphPropsFlags};
 use super::hb_font_t;
@@ -9,6 +8,7 @@ use super::ot_layout::LayoutTable;
 use super::ot_layout::*;
 use super::ot_layout_common::*;
 use super::unicode::hb_unicode_general_category_t;
+use crate::hb::ot_layout_gsubgpos::OT::check_glyph_property;
 use read_fonts::tables::layout::SequenceLookupRecord;
 use read_fonts::types::GlyphId;
 
@@ -63,7 +63,8 @@ pub fn match_input(
         match_positions.resize(count, 0);
     }
 
-    let mut iter = skipping_iterator_t::new(ctx, ctx.buffer.idx, false);
+    let mut iter = skipping_iterator_t::new(ctx, false);
+    iter.reset(ctx.buffer.idx);
     iter.set_glyph_data(0);
     iter.enable_matching(match_func);
 
@@ -147,7 +148,8 @@ pub fn match_backtrack(
     match_func: &match_func_t,
     match_start: &mut usize,
 ) -> bool {
-    let mut iter = skipping_iterator_t::new(ctx, ctx.buffer.backtrack_len(), true);
+    let mut iter = skipping_iterator_t::new(ctx, true);
+    iter.reset(ctx.buffer.backtrack_len());
     iter.set_glyph_data(0);
     iter.enable_matching(match_func);
 
@@ -173,7 +175,8 @@ pub fn match_lookahead(
     // Function should always be called with a non-zero starting index
     // c.f. https://github.com/harfbuzz/rustybuzz/issues/142
     assert!(start_index >= 1);
-    let mut iter = skipping_iterator_t::new(ctx, start_index - 1, true);
+    let mut iter = skipping_iterator_t::new(ctx, true);
+    iter.reset(start_index - 1);
     iter.set_glyph_data(0);
     iter.enable_matching(match_func);
 
@@ -239,9 +242,9 @@ impl<'a> Default for matcher_t<'a> {
 }
 
 impl<'a> matcher_t<'a> {
-
     fn may_match(&self, info: &hb_glyph_info_t, glyph_data: u16) -> may_match_t {
-        if (info.mask & self.mask) == 0 || (self.per_syllable && self.syllable != 0 && self.syllable != info.syllable())
+        if (info.mask & self.mask) == 0
+            || (self.per_syllable && self.syllable != 0 && self.syllable != info.syllable())
         {
             return may_match_t::MATCH_NO;
         }
@@ -284,23 +287,20 @@ pub struct skipping_iterator_t<'a, 'b> {
 }
 
 impl<'a, 'b> skipping_iterator_t<'a, 'b> {
-    pub fn new(
-        ctx: &'a hb_ot_apply_context_t<'a, 'b>,
-        start_buf_index: usize,
-        context_match: bool,
-    ) -> Self {
+    pub fn new(ctx: &'a hb_ot_apply_context_t<'a, 'b>, context_match: bool) -> Self {
         skipping_iterator_t {
             buffer: ctx.buffer,
             face: ctx.face,
             glyph_data: 0,
             buf_len: ctx.buffer.len,
-            buf_idx: start_buf_index,
+            buf_idx: 0,
 
             matcher: matcher_t {
                 matching: None,
                 lookup_props: ctx.lookup_props,
                 // Ignore ZWNJ if we are matching GPOS, or matching GSUB context and asked to.
-                ignore_zwnj: ctx.table_index == TableIndex::GPOS || (context_match && ctx.auto_zwnj),
+                ignore_zwnj: ctx.table_index == TableIndex::GPOS
+                    || (context_match && ctx.auto_zwnj),
                 // Ignore ZWJ if we are matching context, or asked to.
                 ignore_zwj: context_match || ctx.auto_zwj,
                 // Ignore hidden glyphs (like CGJ) during GPOS.
@@ -312,11 +312,7 @@ impl<'a, 'b> skipping_iterator_t<'a, 'b> {
                 },
                 /* Per syllable matching is only for GSUB. */
                 per_syllable: ctx.table_index == TableIndex::GSUB && ctx.per_syllable,
-                syllable: if ctx.buffer.idx == start_buf_index {
-                    ctx.buffer.cur(0).syllable()
-                } else {
-                    0
-                },
+                syllable: 0,
             },
         }
     }
@@ -401,6 +397,21 @@ impl<'a, 'b> skipping_iterator_t<'a, 'b> {
         }
 
         false
+    }
+
+    pub fn reset(&mut self, start_index: usize) {
+        self.buf_idx = start_index;
+        self.buf_len = self.buffer.len;
+        self.matcher.syllable = if self.buf_idx == self.buffer.idx {
+            self.buffer.cur(0).syllable()
+        } else {
+            0
+        };
+    }
+
+    pub fn reset_fast(&mut self, start_index: usize) {
+        // Doesn't set end or syllable. Used by GPOS which doesn't care / change.
+        self.buf_idx = start_index;
     }
 
     fn may_skip(&self, info: &hb_glyph_info_t) -> may_skip_t {
@@ -588,7 +599,11 @@ pub mod OT {
     use super::*;
     use crate::hb::set_digest::hb_set_digest_t;
 
-    pub fn check_glyph_property(face: &hb_font_t, info: &hb_glyph_info_t, match_props: u32) -> bool {
+    pub fn check_glyph_property(
+        face: &hb_font_t,
+        info: &hb_glyph_info_t,
+        match_props: u32,
+    ) -> bool {
         let glyph_props = info.glyph_props();
 
         // Lookup flags are lower 16-bit of match props.


### PR DESCRIPTION
Some sketch on how to remove the circular cycle between skippy-iter and apply-context.