### PR TITLE
[ot_shape] Sync propagate_flags with hb

### DIFF
--- a/src/hb/ot_shape.rs
+++ b/src/hb/ot_shape.rs
@@ -964,5 +964,9 @@ fn propagate_flags(buffer: &mut hb_buffer_t) {
                 info.mask = mask;
             }
         }
+
+        for info in &mut buffer.info[start..end] {
+            info.mask = mask;
+        }
     });
 }


### PR DESCRIPTION
Not sure why this block was not ported before.